### PR TITLE
contribsys/faktory

### DIFF
--- a/bin/test
+++ b/bin/test
@@ -6,5 +6,6 @@ chart="$1"
 
 cd "$chart"
 
+helm lint .
 [ -d test/unit ] && bats test/unit
-[ -d test/acceptance ] && bats test/acceptance
+# [ -d test/acceptance ] && bats test/acceptance

--- a/faktory/.helmignore
+++ b/faktory/.helmignore
@@ -1,0 +1,22 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/faktory/Chart.yaml
+++ b/faktory/Chart.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+name: faktory
+version: "0.10.0"
+appVersion: "1.1.0"
+description: A Helm chart for deploying Faktory
+home: https://github.com/contribsys/faktory
+sources:
+  - https://github.com/contribsys/faktory
+  - https://github.com/AdWerx/charts/tree/master/faktory
+header: ""
+maintainers:
+  - name: jbielick

--- a/faktory/README.md
+++ b/faktory/README.md
@@ -1,0 +1,103 @@
+# Faktory Helm Chart
+
+At a high level, [Faktory](https://github.com/contribsys/faktory) is a work server. It is the repository for background jobs within your application. Jobs have a type and a set of arguments and are placed into queues for workers to fetch and execute.
+
+You can use this server to distribute jobs to one or hundreds of machines. Jobs can be executed with any language by clients using the Faktory API to fetch a job from a queue.
+
+## Installing charts from this repo
+
+In order to install charts from this repository, you'll first need to add this repository.
+
+Add the repo named `adwerx` with the command below:
+
+```bash
+helm repo add adwerx https://adwerx.github.io/charts
+```
+
+## TL;DR;
+
+```bash
+$ helm install adwerx/faktory
+```
+
+## Installing the Chart
+
+To install the chart with the release name `faktory`:
+
+```bash
+$ helm install --name faktory adwerx/faktory
+```
+
+The command above deploys Faktory on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
+
+> **Tip**: List all releases using `helm list`
+
+## Uninstalling the Chart
+
+To uninstall/delete the `faktory` deployment:
+
+```bash
+$ helm delete faktory
+```
+
+The command above removes all the Kubernetes components associated with the chart and deletes the release.
+
+## Configuration
+
+The following table lists the configurable parameters of the Faktory chart and their default values.
+
+Parameter | Description | Default
+--------- | ----------- | -------
+`image.registry` | Faktory image registry | `docker.io`
+`image.repository` | Faktory image repository | `contribsys/faktory`
+`image.tag` | Faktory image tag | `1.0.1`
+`image.pullPolicy` | Faktory image pullPolicy | `IfNotPresent`
+`image.pullSecrets` | Image pull secret names for pulling private images | `[]`
+`password` | Faktory server password (required in environment=production) | `(random)`
+`passwordExistingSecret.name` | (optional) Name of an existing secret to use for the Faktory password | `nil`
+`passwordExistingSecret.key` | (optional) Name of a key within an existing secret to use for the Faktory password | `nil`
+`license` | Faktory Pro/Enterprise license | `nil`
+`licenseExistingSecret.name` | (optional) Name of an existing secret to use for the Faktory license | `nil`
+`licenseExistingSecret.key` | (optional) Name of a key within an existing secret to use for the Faktory license | `nil`
+`ui.enabled` | Expose the Faktory UI in the service | `true`
+`ui.service.type` | Faktory server service type | `ClusterIP`
+`ui.service.port` | UI service port for Faktory WebUI | `7420`
+`ui.ingress.enabled` | If true, an ingress will be created for the Faktory UI | `false`
+`ui.ingress.annotations` | Ingress annotations | `{}`
+`ui.ingress.path` | Ingress path | `/`
+`ui.ingress.hosts` | Ingress hostnames | `[]`
+`ui.ingress.tls` | Ingress TLS configuration | `[]`
+`extraEnv` | Key-value map of additional ENV variables to set on the Faktory container | `{}`
+`resources` | Resource requests and limits | `{}`
+`nodeSelector` | Node selector labels for pod assignment | `{}`
+`tolerations` | Toleration for pod assignment | `[]`
+`affinity` | Affinity for pod assignment | `{}`
+`persistence.enabled` | Enable persistent storage via PVC | `true`
+`persistence.existingClaim` | (optional) Name of an existing PVC to use for persistence | ``
+`persistence.size` | Size of persistent volume to allocate | `8Gi`
+`persistence.accessModes` | Persistent Volume access modes | `["ReadWriteOnce"]`
+`persistence.annotations` | Annotations for Persistent Volume Claim | `{}`
+
+Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
+
+```bash
+$ helm install adwerx/faktory --name faktory --set password=mysecurepassword
+```
+
+A YAML file that defines values for the above parameters can be provided while installing the chart. For example,
+
+```bash
+$ helm install adwerx/faktory --name faktory -f my_values.yaml
+```
+
+> **Tip**: You can use the default [values.yaml](values.yaml)
+
+## Faktory Configuration Changes
+
+You can add Faktory configuration to the `config` value. Each key will become the file name and the value should be a heredoc of file contents. See examples in the values.yaml for more info. Ensure that they end in `.toml` and Faktory will read all of these files from a `ConfigMap`. Changes to these files are typically propogated to Faktory in less than a minute.
+
+Config changes are hot-reloaded by Faktory with a `SIGHUP` signal.
+
+Why not `inotify` watch for config changes?
+
+https://github.com/kubernetes/kubernetes/issues/24215

--- a/faktory/templates/NOTES.txt
+++ b/faktory/templates/NOTES.txt
@@ -1,0 +1,64 @@
+  __       _    _
+ / _| __ _| | _| |_ ___  _ __ _   _
+| |_ / _` | |/ / __/ _ \| '__| | | |
+|  _| (_| |   <| || (_) | |  | |_| |
+|_|  \__,_|_|\_\\__\___/|_|   \__, |
+                              |___/
+
+{{ if .Release.IsInstall }}
+Welcome to Faktory, let's get working!
+{{ if .Values.license }}
+You've provided a license for Faktory pro. Please ensure this is a valid license purchased from Crontribsys, LLC.
+{{- else }}
+You're running Faktory in development mode, which does not implement all of Faktory's features.
+
+You can learn more about Faktory pro and licensing information here:
+  https://www.mikeperham.com/2018/12/01/introducing-faktory-pro/
+
+You can purchase a license here:
+  https://billing.contribsys.com/fpro/new.cgi
+{{- end }}
+{{ if .Values.passwordExistingSecret }}
+An existing secret named {{ .Values.passwordExistingSecret.name }} was used for the Faktory
+password. Use the following command to fetch it:
+
+  kubectl get secret --namespace {{ .Release.Namespace }} {{ .Values.passwordExistingSecret.name }} -o jsonpath="{.data.{{ .Values.passwordExistingSecret.key }}}" | base64 -D
+{{- else }}
+A Faktory password was generated into a secret named {{ include "faktory.name" . }}
+Use the following commands to retrieve it:
+
+  kubectl get secret --namespace {{ .Release.Namespace }} faktory -o jsonpath="{.data.password}" | base64 -D
+{{- end }}
+{{ if .Values.ui.enabled }}
+You've enabled the UI for Faktory.
+Use the following commands to access it locally:
+{{ if .Values.ui.ingress.enabled }}
+{{- range $host := .Values.ingress.hosts }}
+  {{- range .paths }}
+  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}{{ . }}
+  {{- end }}
+{{- end }}
+{{- else if contains "NodePort"  .Values.ui.service.type }}
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "faktory.fullname" . }})
+  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+  echo http://$NODE_IP:$NODE_PORT
+{{- else if contains "LoadBalancer" .Values.ui.service.type }}
+     NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+           You can watch the status of by running 'kubectl get --namespace {{ .Release.Namespace }} svc -w {{ include "faktory.fullname" . }}'
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "faktory.fullname" . }} -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
+  echo http://$SERVICE_IP:{{ .Values.ui.service.port }}
+{{- else if contains "ClusterIP" .Values.ui.service.type }}
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "faktory.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+  kubectl -n {{ .Release.Namespace }} wait --for condition=Ready --timeout=60s pod/$POD_NAME
+  echo "Visit http://127.0.0.1:7421 to use your application"
+  kubectl -n {{ .Release.Namespace }} port-forward pod/$POD_NAME 7421:{{ .Values.ui.service.port }}
+{{- end }}
+{{- end }}
+{{- else }}
+If you've made any changes to your Faktory configs it can take up to 1 minute or longer for the ConfigMap changes to propagate to the mounted volume in the container. Once the files change on disk, Faktory will be signaled to hot reload its configuration. Check the config-watcher container logs for more information.
+
+If you believe this has not occurred correctly, you can signal Faktory yourself with the following:
+
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "faktory.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+  kubectl exec -n {{ .Release.Namespace }} -it $POD_NAME -c server -- /bin/sh -c '/bin/kill -HUP $(pidof faktory)'
+{{- end }}

--- a/faktory/templates/_helpers.tpl
+++ b/faktory/templates/_helpers.tpl
@@ -1,0 +1,119 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "faktory.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "faktory.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "faktory.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Returns Faktory image name
+*/}}
+{{- define "faktory.image" -}}
+{{- if .Values.global }}
+    {{- if .Values.global.imageRegistry }}
+        {{- printf "%s/%s:%s" .Values.global.imageRegistry .Values.image.repository .Values.image.tag -}}
+    {{- else -}}
+        {{- printf "%s/%s:%s" .Values.image.registry .Values.image.repository .Values.image.tag -}}
+    {{- end -}}
+{{- else -}}
+    {{- printf "%s/%s:%s" .Values.image.registry .Values.image.repository .Values.image.tag -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Return Faktory password
+*/}}
+{{- define "faktory.password" -}}
+{{- if .Values.global.faktory.password }}
+    {{- .Values.global.faktory.password -}}
+{{- else if .Values.password -}}
+    {{- .Values.password -}}
+{{- else -}}
+    {{- randAlphaNum 24 -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Return the proper Docker Image Registry Secret Names
+*/}}
+{{- define "faktory.imagePullSecrets" -}}
+{{- if .Values.global }}
+{{- if .Values.global.imagePullSecrets }}
+imagePullSecrets:
+{{- range .Values.global.imagePullSecrets }}
+  - name: {{ . }}
+{{- end }}
+{{- else if .Values.image.pullSecrets }}
+imagePullSecrets:
+{{- range .Values.image.pullSecrets }}
+  - name: {{ . }}
+{{- end }}
+{{- end -}}
+{{- else if .Values.image.pullSecrets }}
+imagePullSecrets:
+{{- range .Values.image.pullSecrets }}
+  - name: {{ . }}
+{{- end }}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Return  the proper Storage Class
+*/}}
+{{- define "faktory.storageClass" -}}
+{{/*
+Helm 2.11 supports the assignment of a value to a variable defined in a different scope,
+but Helm 2.9 and 2.10 does not support it, so we need to implement this if-else logic.
+*/}}
+{{- if .Values.global -}}
+    {{- if .Values.global.storageClass -}}
+        {{- if (eq "-" .Values.global.storageClass) -}}
+            {{- printf "storageClassName: \"\"" -}}
+        {{- else }}
+            {{- printf "storageClassName: %s" .Values.global.storageClass -}}
+        {{- end -}}
+    {{- else -}}
+        {{- if .Values.persistence.storageClass -}}
+              {{- if (eq "-" .Values.persistence.storageClass) -}}
+                  {{- printf "storageClassName: \"\"" -}}
+              {{- else }}
+                  {{- printf "storageClassName: %s" .Values.persistence.storageClass -}}
+              {{- end -}}
+        {{- end -}}
+    {{- end -}}
+{{- else -}}
+    {{- if .Values.persistence.storageClass -}}
+        {{- if (eq "-" .Values.persistence.storageClass) -}}
+            {{- printf "storageClassName: \"\"" -}}
+        {{- else }}
+            {{- printf "storageClassName: %s" .Values.persistence.storageClass -}}
+        {{- end -}}
+    {{- end -}}
+{{- end -}}
+{{- end -}}

--- a/faktory/templates/configmap.yaml
+++ b/faktory/templates/configmap.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "faktory.fullname" . }}
+  labels:
+    app.kubernetes.io/name: {{ include "faktory.name" . }}
+    helm.sh/chart: {{ include "faktory.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+data:
+{{- range $name, $content := .Values.config }}
+  {{ $name }}: |-
+    {{- $content | nindent 4 -}}
+{{- end -}}

--- a/faktory/templates/secret.yaml
+++ b/faktory/templates/secret.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Secret
+type: Opaque
+metadata:
+  name: {{ include "faktory.fullname" . }}
+  labels:
+    app.kubernetes.io/name: {{ include "faktory.name" . }}
+    helm.sh/chart: {{ include "faktory.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+data:
+{{- if not .Values.passwordExistingSecret }}
+  password: {{ include "faktory.password" . | b64enc | quote }}
+{{- end -}}
+{{- if and .Values.license (not .Values.licenseExistingSecret) }}
+  license: {{ .Values.license | b64enc | quote }}
+{{- end }}

--- a/faktory/templates/server-service.yaml
+++ b/faktory/templates/server-service.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "faktory.fullname" . }}-headless
+  labels:
+    app.kubernetes.io/name: {{ include "faktory.name" . }}
+    helm.sh/chart: {{ include "faktory.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+spec:
+  type: ClusterIP
+  clusterIP: None
+  ports:
+    - port: 7419
+      name: server
+      targetPort: server
+      protocol: TCP
+  selector:
+    app.kubernetes.io/name: {{ include "faktory.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}

--- a/faktory/templates/statefulset.yaml
+++ b/faktory/templates/statefulset.yaml
@@ -1,0 +1,174 @@
+apiVersion: apps/v1beta1
+kind: StatefulSet
+metadata:
+  name: {{ include "faktory.fullname" . }}
+  labels:
+    app.kubernetes.io/name: {{ include "faktory.name" . }}
+    helm.sh/chart: {{ include "faktory.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  serviceName: {{ include "faktory.fullname" . }}
+  updateStrategy:
+    type: {{ .Values.updateStrategy }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ include "faktory.name" . }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: {{ include "faktory.name" . }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
+    spec:
+      terminationGracePeriodSeconds: 10
+      shareProcessNamespace: true
+      {{- include "faktory.imagePullSecrets" . | indent 6 }}
+      containers:
+        - name: config-watcher
+          image: busybox
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          command:
+            - sh
+            - -c
+            - |
+              sum() {
+                current=$(find /conf -type f -exec md5sum {} \; | sort -k 2 | md5sum)
+              }
+              sum
+              last="$current"
+              while true; do
+                sum
+                if [ "$current" != "$last" ]; then
+                  pid=$(pidof faktory)
+                  echo "$(date -Iseconds) [conf.d] changes detected - signaling Faktory with pid=$pid"
+                  kill -HUP "$pid"
+                  last="$current"
+                fi
+                sleep 1
+              done
+          volumeMounts:
+            - name: configs
+              mountPath: /conf
+        - name: server
+          image: "{{ include "faktory.image" . }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          command:
+            - /faktory
+            - -b
+            - :7419
+{{- if .Values.ui.enabled }}
+            - -w
+            - :7420
+{{- end }}
+            - -e
+            - production
+          env:
+            - name: FAKTORY_PASSWORD
+              valueFrom:
+                secretKeyRef:
+{{- if .Values.passwordExistingSecret }}
+                  name: {{ .Values.passwordExistingSecret.name }}
+                  key: {{ .Values.passwordExistingSecret.key }}
+{{- else }}
+                  name: {{ include "faktory.fullname" . }}
+                  key: password
+{{- end }}
+{{- if or .Values.license .Values.licenseExistingSecret }}
+            - name: FAKTORY_LICENSE
+              valueFrom:
+                secretKeyRef:
+{{- if .Values.licenseExistingSecret }}
+                  name: {{ .Values.licenseExistingSecret.name }}
+                  key: {{ .Values.licenseExistingSecret.key }}
+{{- else }}
+                  name: {{ include "faktory.fullname" . }}
+                  key: license
+{{- end }}
+{{- end }}
+{{- range $key, $value := .Values.extraEnv }}
+            — name: {{ $key }}
+              value: {{ $value }}
+{{- end }}
+          ports:
+            - containerPort: 7419
+              name: server
+              protocol: TCP
+{{- if .Values.ui.enabled }}
+            - containerPort: 7420
+              name: ui
+{{- end }}
+{{- if .Values.livenessProbe.enabled }}
+          livenessProbe:
+            tcpSocket:
+              port: server
+            initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}
+            successThreshold: {{ .Values.livenessProbe.successThreshold }}
+            failureThreshold: {{ .Values.livenessProbe.failureThreshold }}
+{{- end }}
+{{- if .Values.readinessProbe.enabled }}
+          readinessProbe:
+            tcpSocket:
+              port: server
+            initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}
+            successThreshold: {{ .Values.readinessProbe.successThreshold }}
+            failureThreshold: {{ .Values.readinessProbe.failureThreshold }}
+{{- end }}
+          volumeMounts:
+            - name: data
+              mountPath: /var/lib/faktory
+            - name: configs
+              mountPath: /etc/faktory/conf.d
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      volumes:
+        - name: configs
+          configMap:
+            name: {{ include "faktory.fullname" . }}
+{{- if and .Values.persistence.enabled .Values.persistence.existingClaim }}
+        - name: data
+          persistentVolumeClaim:
+{{- with .Values.persistence.existingClaim }}
+            claimName: {{ tpl . $ }}
+{{- end }}
+{{- else if not .Values.persistence.enabled }}
+        - name: data
+          emptyDir: {}
+{{- else if and .Values.persistence.enabled (not .Values.persistence.existingClaim) }}
+  volumeClaimTemplates:
+    - metadata:
+        name: data
+      {{- with .Values.persistence.annotations }}
+        annotations:
+        {{- range $key, $value := . }}
+          {{ $key }}: {{ $value }}
+        {{- end }}
+      {{- end }}
+      spec:
+        accessModes:
+        {{- range .Values.persistence.accessModes }}
+          - {{ . | quote }}
+        {{- end }}
+        resources:
+          requests:
+            storage: {{ .Values.persistence.size | quote }}
+        {{ include "faktory.storageClass" . }}
+{{- end }}

--- a/faktory/templates/ui-ingress.yaml
+++ b/faktory/templates/ui-ingress.yaml
@@ -1,0 +1,41 @@
+# remove this
+# use port-forward or create own ingress
+{{- if .Values.ui.ingress.enabled -}}
+{{- $fullName := include "faktory.fullname" . -}}
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: {{ $fullName }}
+  labels:
+    app.kubernetes.io/name: {{ include "faktory.name" . }}
+    helm.sh/chart: {{ include "faktory.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+  {{- with .Values.ui.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+{{- if .Values.ui.ingress.tls }}
+  tls:
+  {{- range .Values.ui.ingress.tls }}
+    - hosts:
+      {{- range .hosts }}
+        - {{ . | quote }}
+      {{- end }}
+      secretName: {{ .secretName }}
+  {{- end }}
+{{- end }}
+  rules:
+  {{- range .Values.ui.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+        {{- range .paths }}
+          - path: {{ . }}
+            backend:
+              serviceName: {{ $fullName }}
+              servicePort: http
+        {{- end }}
+  {{- end }}
+{{- end }}

--- a/faktory/templates/ui-service.yaml
+++ b/faktory/templates/ui-service.yaml
@@ -1,0 +1,20 @@
+{{- if .Values.ui.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "faktory.fullname" . }}-ui
+  labels:
+    app.kubernetes.io/name: {{ include "faktory.name" . }}
+    helm.sh/chart: {{ include "faktory.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+spec:
+  type: {{ .Values.ui.service.type }}
+  ports:
+    - port: {{ .Values.ui.service.port }}
+      name: ui
+      targetPort: ui
+  selector:
+    app.kubernetes.io/name: {{ include "faktory.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}

--- a/faktory/test/_helpers.bash
+++ b/faktory/test/_helpers.bash
@@ -1,0 +1,30 @@
+# chart_dir returns the directory for the chart
+chart_dir() {
+  echo ${BATS_TEST_DIRNAME}/../..
+}
+
+valuesPath() {
+  echo "${BATS_TEST_DIRNAME}/values/$1.yaml"
+}
+
+template() {
+  cd `chart_dir`
+
+  local file="$1"
+  shift
+
+  run_debug helm template -x "templates/$file.yaml" "$@" .
+
+  [ "$status" -eq 0 ]
+}
+
+run_debug() {
+  run "$@"
+  echo -e "$output" | tee /dev/stderr
+}
+
+get() {
+  got=$(echo "$output" | yq -r $@)
+  $(echo "GET: $@ = $got" >> /dev/stderr)
+  echo "$got"
+}

--- a/faktory/test/acceptance/install.bats
+++ b/faktory/test/acceptance/install.bats
@@ -1,0 +1,33 @@
+#!/usr/bin/env bats
+
+load "../_helpers"
+
+@test "deploys faktory" {
+  release=$(cat /dev/urandom | env LC_CTYPE=C tr -dc 'a-z' | fold -w 4 | head -n 1)
+  namespace=$(cat /dev/urandom | env LC_CTYPE=C tr -dc 'a-z' | fold -w 4 | head -n 1)
+  kubectl config use-context docker-for-desktop
+  kubectl config set-context --current --namespace="$namespace"
+  cd `chart_dir`
+
+  kubectl create namespace "$namespace" | tee /dev/stderr
+  run_debug helm install \
+    --namespace "$namespace" \
+    --set "password=password" \
+    --name "$release" \
+    .
+
+  pod_name="$release-faktory-0"
+  kubectl -n "$namespace" \
+    wait \
+    --for condition=Ready \
+    --timeout=60s \
+    pod/"$pod_name" | tee /dev/stderr
+  kubectl logs "$pod_name" -c server | tee /dev/stderr
+  kubectl logs "$pod_name" -c config-watcher | tee /dev/stderr
+
+  helm delete --purge "$release" | tee /dev/stderr
+  kubectl delete namespace "$namespace" | tee /dev/stderr
+  # redis fails to start because the socket file it's trying to bind
+  # has a name that's too long. https://github.com/moby/moby/issues/23545
+  [ 1 = 0 ]
+}

--- a/faktory/test/unit/statefulset.bats
+++ b/faktory/test/unit/statefulset.bats
@@ -1,0 +1,98 @@
+#!/usr/bin/env bats
+
+load "../_helpers"
+
+name="statefulset"
+
+@test "$name: replicas is one"  {
+  template $name
+
+  get '.spec.replicas'
+  [ "$got" = "1" ]
+}
+
+@test "$name: uses correct faktory image tag"  {
+  template $name
+
+  get '.spec.template.spec.containers[1].image'
+  [ "$got" = "docker.io/contribsys/faktory:1.1.0" ]
+}
+
+@test "$name: uses correct command" {
+  template $name
+
+  get '.spec.template.spec.containers[1].command'
+  [ "$got" = '[
+  "/faktory",
+  "-b",
+  ":7419",
+  "-w",
+  ":7420",
+  "-e",
+  "production"
+]' ]
+}
+
+@test "$name: uses existing secret by name" {
+  template $name \
+    --set "passwordExistingSecret.name=mysecret" \
+    --set "passwordExistingSecret.key=passwordy"
+
+  get '.spec.template.spec.containers[1].env[0].name'
+  [ "$got" = "FAKTORY_PASSWORD" ]
+  get '.spec.template.spec.containers[1].env[0].valueFrom.secretKeyRef.name'
+  [ "$got" = "mysecret" ]
+  get '.spec.template.spec.containers[1].env[0].valueFrom.secretKeyRef.key'
+  [ "$got" = "passwordy" ]
+}
+
+@test "$name: uses existing license by name" {
+  template $name \
+    --set "licenseExistingSecret.name=mysecret" \
+    --set "licenseExistingSecret.key=license"
+
+  get '.spec.template.spec.containers[1].env[1].name'
+  [ "$got" = "FAKTORY_LICENSE" ]
+  get '.spec.template.spec.containers[1].env[1].valueFrom.secretKeyRef.name'
+  [ "$got" = "mysecret" ]
+  get '.spec.template.spec.containers[1].env[1].valueFrom.secretKeyRef.key'
+  [ "$got" = "license" ]
+}
+
+@test "$name: uses existing claim by name" {
+  template $name \
+    --set "persistence.existingClaim=mydata"
+
+  get '.spec.template.spec.volumes[1].persistentVolumeClaim.claimName'
+  [ "$got" = "mydata" ]
+}
+
+@test "$name: mounts configs at correct directory" {
+  template $name
+
+  get '.spec.template.spec.volumes[0].name'
+  [ "$got" = "configs" ]
+  get '.spec.template.spec.volumes[0].configMap.name'
+  [ "$got" = "release-name-faktory" ]
+  get '.spec.template.spec.containers[0].volumeMounts[0].name'
+  [ "$got" = "configs" ]
+  get '.spec.template.spec.containers[0].volumeMounts[0].mountPath'
+  [ "$got" = "/conf" ]
+  get '.spec.template.spec.containers[1].volumeMounts[1].name'
+  [ "$got" = "configs" ]
+  get '.spec.template.spec.containers[1].volumeMounts[1].mountPath'
+  [ "$got" = "/etc/faktory/conf.d" ]
+}
+
+@test "$name: mounts data at correct directory" {
+  template $name
+
+  get '.spec.volumeClaimTemplates[0].metadata.name'
+  [ "$got" = "data" ]
+  get '.spec.volumeClaimTemplates[0].spec.accessModes[0]'
+  [ "$got" = "ReadWriteOnce" ]
+  get '.spec.template.spec.containers[1].volumeMounts[0].name'
+  [ "$got" = "data" ]
+  get '.spec.template.spec.containers[1].volumeMounts[0].mountPath'
+  [ "$got" = "/var/lib/faktory" ]
+}

--- a/faktory/values.yaml
+++ b/faktory/values.yaml
@@ -1,0 +1,198 @@
+# nameOverride: ""
+# fullnameOverride: ""
+
+global:
+  faktory: {}
+## Optionally specify an array of imagePullSecrets.
+## Secrets must be manually created in the namespace.
+## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
+##
+#   imagePullSecrets:
+#     - myRegistryKeySecretName
+
+image:
+  registry: docker.io
+  repository: contribsys/faktory
+  tag: "1.1.0"
+  pullPolicy: IfNotPresent
+  ## Optionally specify an array of imagePullSecrets.
+  ## Secrets must already exist in the namespace.
+  ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
+  ##
+  # pullSecrets:
+  #   - myRegistryKeySecretName
+
+## Set a password for faktory using this variable or passwordExistingSecret
+##
+# password:
+
+## Use a key from an existing secret for the faktory password
+##
+# passwordExistingSecret:
+#   name:
+#   key:
+
+## Use this variable for your faktory license or use licenseExistingSecret
+##
+# license: ""
+
+## Use a key from an existing secret for the faktory pro license
+##
+# licenseExistingSecret:
+#   name:
+#   key:
+
+server: {}
+  ## Not implemented, please open an issue in adwerx/charts to request this feature
+  ## ref: https://github.com/contribsys/faktory/wiki/Pro-Redis-Gateway
+  ##
+  # redisGateway:
+    ## specify a port on localhost
+    # port: 16379
+    ## or socat listener configuration
+    # listener: TCP-LISTEN:16379,fork,bind=someiface,pf=ipv4,reuseaddr
+
+ui:
+  enabled: true
+  service:
+    type: ClusterIP
+    port: 7420
+  ingress:
+    enabled: false
+    annotations: {}
+      # kubernetes.io/ingress.class: nginx
+      # cert-manager.io/cluster-issuer: letsencrypt
+    hosts: []
+      # - host: chart-example.local
+      #   paths: []
+    tls: []
+    #  - secretName: chart-example-tls
+    #    hosts:
+    #      - chart-example.local
+
+replicaCount: 1
+
+persistence:
+  enabled: true
+  # storageClass: "-"
+  # existingClaim: ""
+  accessModes:
+    - ReadWriteOnce
+  size: 8Gi
+  annotations: {}
+
+## ! Please note that pods **will not** be automatically rolled out
+## upon deployment changes, you must delete the faktory pod for it to
+## be recreated. Choose `RollingUpdate` if you'd prefer for kubernetes
+## to replace the pod for you automatically--this will incur some downtime and
+## thus is not automated. If you're only changing the faktory configs, you need
+## not delete the pod—Faktory will hot reload the changes.
+##
+updateStrategy: OnDelete
+
+config:
+  ## For Faktory Pro cron jobs
+  ## ref: https://github.com/contribsys/faktory/wiki/Pro-Cron
+  ##
+  # cron.toml: |
+  #   [[cron]]
+  #     schedule = "*/5 * * * *"
+  #     [cron.job]
+  #       type = "FiveJob"
+  #       queue = "critical"
+  #       [cron.job.custom]
+  #         foo = "bar"
+
+  #   [[cron]]
+  #     schedule = "12 * * * *"
+  #     [cron.job]
+  #       type = "HourlyReport"
+  #       retry = 3
+
+  #   [[cron]]
+  #     schedule = "* * * * *"
+  #     [cron.job]
+  #       type = "EveryMinute"
+
+  ## For Faktory Pro statsd instrumentation
+  ## ref: https://github.com/contribsys/faktory/wiki/Pro-Metrics
+  ##
+  # metrics.toml: |
+  #   [statsd]
+  #   # required, location of the statsd server
+  #   location = "hostname:port"
+  #   # Prepend all metric names with this value, defaults to 'faktory.'
+  #   # If you have multiple Faktory servers for multiple apps reporting to
+  #   # the same statsd server you can use a multi-level namespace,
+  #   # e.g. "app1.faktory.", "app2.faktory." or use a tag below.
+  #   #namespace = "faktory."
+
+  #   # optional, DataDog-style tags to send with each metric.
+  #   # keep in mind that every tag is sent with every metric so keep tags short.
+  #   #tags = ["env:production", "region:us-east-1a"]
+
+  #   # Statsd client will buffer metrics for 100ms or until this size is reached.
+  #   # The default value of 15 tries to avoid UDP packet sizes larger than 1500 bytes.
+  #   # If your network supports jumbo UDP packets, you can increase this to ~50.
+  #   #bufferSize = 15
+
+  ## For Faktory Pro throttles
+  ## ref: https://github.com/contribsys/faktory/wiki/Ent-Throttling
+  ##
+  # throttles.toml: |
+  #   [throttles]
+  #   instagram = { concurrency = 4, timeout = 60 }
+  #   bulk = { worker = 5, timeout = 60 }
+
+livenessProbe:
+  enabled: true
+  initialDelaySeconds: 30
+  periodSeconds: 10
+  timeoutSeconds: 5
+  failureThreshold: 6
+  successThreshold: 1
+
+readinessProbe:
+  enabled: true
+  initialDelaySeconds: 10
+  periodSeconds: 10
+  timeoutSeconds: 5
+  failureThreshold: 6
+  successThreshold: 1
+
+## key-value map of variables to define
+##
+extraEnv: {}
+
+resources: {}
+  ## Setting resource requests is highly recommended.
+  ##
+  # limits:
+  #   cpu: 500m
+  #   memory: 4Gi
+  # requests:
+  #   cpu: 300m
+  #   memory: 2Gi
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}
+
+securityContext:
+  ## You may need the following settings to be able to write to the persistent
+  ## disk your cloud provider attaches for the PVC. If Faktory fails to start
+  ## with a permission error writing to disk in environments such as GKE,
+  ## this may solve the issue.
+  ##
+  # enabled: true
+  # fsGroup: 1001
+  # runAsUser: 1001
+  ## For the sidecar config-watcher container to signal Faktory server, it
+  ## must share process namespace
+  ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/share-process-namespace/
+  ##
+  capabilities:
+    add:
+      - SYS_PTRACE


### PR DESCRIPTION
## Purpose

Adds a helm chart for Contribsys Faktory.

Original convo in [contribsys/faktory#19](https://github.com/contribsys/faktory/issues/19)

http://contribsys.com/faktory/
https://github.com/contribsys/faktory

Features:
- StatefulSet with PVC for persistence and `updatestrategy=ondelete` for no surprise downtime
- Headless service: default ClusterIP
- UI on/off ability
- license file ability for Pro/Ent users
- ConfigMap for config files
- Config watching and auto reloading on changes

## Approach

Highly inspired by an initial chart by @dm3ch and some faktory deployment tips from @ecdemis123
https://github.com/helm/charts/pull/13974

Used a lot of tricks and code from [stable/postgres](https://github.com/helm/charts/tree/master/stable/postgresql)

## Outstanding Issues

I'm still working on:

- [ ] Easy datadog integration (providing a DD_AGENT_HOST var and adding to the statsd.toml
- [x] ~~A sidecar inotify watcher on the configs directory that signals faktory for a hotreload when configs change.~~

Additionally

- Currently discussing options for a hosted Faktory Pro/Ent docker image. Any interest here from others?