### PR TITLE
Wrong value types

### DIFF
--- a/awx/values.yaml
+++ b/awx/values.yaml
@@ -19,8 +19,8 @@ web:
     # requests:
     #  cpu: "1"
     #  memory: "1Gi"
-  extraVolumes: {}
-  extraVolumeMounts: {}
+  extraVolumes: []
+  extraVolumeMounts: []
   nodeSelector: {}
   tolerations: []
   affinity: {}


### PR DESCRIPTION
#### What this PR does / why we need it:
This PR fixes an error introduced on the previous one #7, the default value on `values.yaml` for the extraVolumes and estraVolumeMounts.