### PR TITLE
[faktory] Fix ingress reference in Faktory's NOTES.txt and README.md

### DIFF
--- a/faktory/Chart.yaml
+++ b/faktory/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: faktory
-version: "0.10.1"
+version: "0.10.2"
 appVersion: "1.1.0"
 description: A Helm chart for deploying Faktory
 home: https://github.com/contribsys/faktory

--- a/faktory/README.md
+++ b/faktory/README.md
@@ -64,8 +64,7 @@ Parameter | Description | Default
 `ui.service.port` | UI service port for Faktory WebUI | `7420`
 `ui.ingress.enabled` | If true, an ingress will be created for the Faktory UI | `false`
 `ui.ingress.annotations` | Ingress annotations | `{}`
-`ui.ingress.path` | Ingress path | `/`
-`ui.ingress.hosts` | Ingress hostnames | `[]`
+`ui.ingress.hosts` | Ingress hostnames and paths. E.g. `[{ host: "example.com", path: "/faktory" }]` | `[]`
 `ui.ingress.tls` | Ingress TLS configuration | `[]`
 `extraEnv` | Key-value map of additional ENV variables to set on the Faktory container | `{}`
 `resources` | Resource requests and limits | `{}`

--- a/faktory/templates/NOTES.txt
+++ b/faktory/templates/NOTES.txt
@@ -33,9 +33,9 @@ Use the following commands to retrieve it:
 You've enabled the UI for Faktory.
 Use the following commands to access it locally:
 {{ if .Values.ui.ingress.enabled }}
-{{- range $host := .Values.ingress.hosts }}
+{{- range $host := .Values.ui.ingress.hosts }}
   {{- range .paths }}
-  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}{{ . }}
+  http{{ if $.Values.ui.ingress.tls }}s{{ end }}://{{ $host.host }}{{ . }}
   {{- end }}
 {{- end }}
 {{- else if contains "NodePort"  .Values.ui.service.type }}


### PR DESCRIPTION
#### What this PR does / why we need it:

`helm template` is failing if I try to enable Faktory UI:

```yaml
faktory:
  ui:
    ingress:
      enabled: yes
      hosts:
        - host: example.com
          path: /admin/faktory
```

Fix README along the way.

#### Workaround

Duplicate ingress in values:

```yaml
faktory:
  ui:
    ingress: &faktory-ingress
      hosts:
        - host: example.com
          path: /admin/faktory

  ingress:
    <<: *faktory-ingress
```

#### Special notes for your reviewer:

#### Checklist
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
