### PR TITLE
[faktory] Add Kubernetes 1.16+ compatibility

### DIFF
--- a/faktory/Chart.yaml
+++ b/faktory/Chart.yaml
@@ -1,7 +1,8 @@
 apiVersion: v1
 name: faktory
-version: "0.10.2"
+version: "0.10.3"
 appVersion: "1.1.0"
+kubeVersion: ">= 1.9.0"
 description: A Helm chart for deploying Faktory
 home: https://github.com/contribsys/faktory
 icon: https://contribsys.com/images/faktory-logo.svg

--- a/faktory/templates/statefulset.yaml
+++ b/faktory/templates/statefulset.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: {{ include "faktory.fullname" . }}

--- a/faktory/templates/ui-ingress.yaml
+++ b/faktory/templates/ui-ingress.yaml
@@ -1,7 +1,7 @@
 # remove this
 # use port-forward or create own ingress
 {{- if .Values.ui.ingress.enabled -}}
-{{- $fullName := include "faktory.fullname" . -}}
+{{- $fullName := include "faktory.fullname" . }}
 apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:


### PR DESCRIPTION
#### What this PR does / why we need it:

 1. Fix StatefulSet definition to be compatible with Kubernetes 1.16+
    
    StatefulSets were stabilized and thus removed from experimental apis in Kubernetes 1.16 (current version is 1.18).
    
    See https://kubernetes.io/blog/2019/07/18/api-deprecations-in-1-16/

    > StatefulSet in the apps/v1beta1 and apps/v1beta2 API versions is no longer served
    >
    > Migrate to use the apps/v1 API version, available since v1.9. Existing persisted data can be retrieved/updated via the new version.

 2. Fix spacing issues that breaks manifest (apiVersion goes into preceding comment line)

#### Benefits

Compatibility with currently used stable k8s versions: 1.16+

#### Possible drawbacks

Broken compatibility with k8s before 1.9

#### Checklist
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
