### PR TITLE
[faktory] Fix service reference from Ingress for Web UI

### DIFF
--- a/faktory/Chart.yaml
+++ b/faktory/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: faktory
-version: "0.10.3"
+version: "0.10.4"
 appVersion: "1.1.0"
 kubeVersion: ">= 1.9.0"
 description: A Helm chart for deploying Faktory

--- a/faktory/README.md
+++ b/faktory/README.md
@@ -100,3 +100,22 @@ Config changes are hot-reloaded by Faktory with a `SIGHUP` signal.
 Why not `inotify` watch for config changes?
 
 https://github.com/kubernetes/kubernetes/issues/24215
+
+## Examples
+
+### Expose Faktory Web UI on subpath
+
+If your cluster is using Nginx Ingress controller, then you can use [configuration snippet](https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/annotations/#configuration-snippet) to specify `X-Script-Name` header.
+
+```yaml
+ui:
+  ingress:
+    enabled: yes
+    hosts:
+      - host: example.com
+        paths:
+          - /faktory
+    annotations:
+      nginx.ingress.kubernetes.io/configuration-snippet: |
+        proxy_set_header X-Script-Name /faktory;
+```

--- a/faktory/templates/ui-ingress.yaml
+++ b/faktory/templates/ui-ingress.yaml
@@ -34,8 +34,8 @@ spec:
         {{- range .paths }}
           - path: {{ . }}
             backend:
-              serviceName: {{ $fullName }}
-              servicePort: http
+              serviceName: {{ $fullName }}-ui
+              servicePort: ui
         {{- end }}
   {{- end }}
 {{- end }}


### PR DESCRIPTION
#### What this PR does / why we need it:

 1. Fixes service reference in ingress (both service name and port was wrong)
 2. Documents running Faktory Web UI on subpath. See See https://github.com/contribsys/faktory/wiki/Administration#running-behind-a-reverse-proxy

- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)
