### PR TITLE
[faktory]: Prometheus metrics exporter with Service Monitor for discovery

### DIFF
--- a/faktory/Chart.yaml
+++ b/faktory/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: faktory
-version: "0.10.4"
+version: "0.11.0"
 appVersion: "1.1.0"
 kubeVersion: ">= 1.9.0"
 description: A Helm chart for deploying Faktory

--- a/faktory/README.md
+++ b/faktory/README.md
@@ -76,6 +76,10 @@ Parameter | Description | Default
 `persistence.size` | Size of persistent volume to allocate | `8Gi`
 `persistence.accessModes` | Persistent Volume access modes | `["ReadWriteOnce"]`
 `persistence.annotations` | Annotations for Persistent Volume Claim | `{}`
+`metrics.enabled` | Enable export of Prometheus metrics about Faktory instance state | `false`
+`metrics.image.repository` | Prometheus exporter sidecar image name | `envek/faktory_exporter`
+`metrics.image.repository` | Prometheus exporter sidecar image tag | `0.4.0`
+`metrics.image.pullPolicy` | Prometheus exporter sidecar image pull policy | `IfNotPresent`
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 

--- a/faktory/README.md
+++ b/faktory/README.md
@@ -80,6 +80,10 @@ Parameter | Description | Default
 `metrics.image.repository` | Prometheus exporter sidecar image name | `envek/faktory_exporter`
 `metrics.image.repository` | Prometheus exporter sidecar image tag | `0.4.0`
 `metrics.image.pullPolicy` | Prometheus exporter sidecar image pull policy | `IfNotPresent`
+`metrics.serviceMonitor.enabled` | Enable creation of ServiceMonitor resource for automatic metrics discovery by Proemtheus operator | `false`
+`metrics.serviceMonitor.namespace` | Namespace to create Service Monitor in (if differs from chart's namespace) | _chart's namespace_
+`metrics.serviceMonitor.interval` | Metrics scrape interval | _Prometheus default_
+`metrics.serviceMonitor.selector` | Labels that should be present in service monitor to be discovered | `{}`
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 

--- a/faktory/README.md
+++ b/faktory/README.md
@@ -80,10 +80,10 @@ Parameter | Description | Default
 `metrics.image.repository` | Prometheus exporter sidecar image name | `envek/faktory_exporter`
 `metrics.image.repository` | Prometheus exporter sidecar image tag | `0.4.0`
 `metrics.image.pullPolicy` | Prometheus exporter sidecar image pull policy | `IfNotPresent`
-`metrics.serviceMonitor.enabled` | Enable creation of ServiceMonitor resource for automatic metrics discovery by Proemtheus operator | `false`
+`metrics.serviceMonitor.enabled` | Enable creation of ServiceMonitor resource for automatic metrics discovery by Prometheus operator | `false`
 `metrics.serviceMonitor.namespace` | Namespace to create Service Monitor in (if differs from chart's namespace) | _chart's namespace_
 `metrics.serviceMonitor.interval` | Metrics scrape interval | _Prometheus default_
-`metrics.serviceMonitor.selector` | Labels that should be present in service monitor to be discovered | `{}`
+`metrics.serviceMonitor.labels` | Labels that should be present in service monitor to be discovered | `{}`
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 

--- a/faktory/templates/server-service.yaml
+++ b/faktory/templates/server-service.yaml
@@ -15,7 +15,7 @@ spec:
       name: server
       targetPort: server
       protocol: TCP
-{{- if and (.Values.metrics.enabled) (.Values.metrics.serviceMonitor.enabled) }}
+{{- if .Values.metrics.enabled }}
     - port: 9386
       name: metrics
       targetPort: metrics

--- a/faktory/templates/server-service.yaml
+++ b/faktory/templates/server-service.yaml
@@ -15,6 +15,11 @@ spec:
       name: server
       targetPort: server
       protocol: TCP
+{{- if and (.Values.metrics.enabled) (.Values.metrics.serviceMonitor.enabled) }}
+    - port: 9386
+      name: metrics
+      targetPort: metrics
+{{- end }}
   selector:
     app.kubernetes.io/name: {{ include "faktory.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}

--- a/faktory/templates/servicemonitor.yaml
+++ b/faktory/templates/servicemonitor.yaml
@@ -9,11 +9,11 @@ metadata:
   namespace: {{ .Release.Namespace }}
   {{- end }}
   labels:
-    app: {{ template "faktory.name" . }}
-    chart: {{ template "faktory.chart" . }}
-    release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
-    {{- range $key, $value := .Values.metrics.serviceMonitor.selector }}
+    app.kubernetes.io/name: {{ include "faktory.name" . }}
+    helm.sh/chart: {{ include "faktory.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    {{- range $key, $value := .Values.metrics.serviceMonitor.labels }}
     {{ $key }}: {{ $value | quote }}
     {{- end }}
 spec:

--- a/faktory/templates/servicemonitor.yaml
+++ b/faktory/templates/servicemonitor.yaml
@@ -1,0 +1,32 @@
+{{- if and (.Values.metrics.enabled) (.Values.metrics.serviceMonitor.enabled) }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "faktory.fullname" . }}
+  {{- if .Values.metrics.serviceMonitor.namespace }}
+  namespace: {{ .Values.metrics.serviceMonitor.namespace }}
+  {{- else }}
+  namespace: {{ .Release.Namespace }}
+  {{- end }}
+  labels:
+    app: {{ template "faktory.name" . }}
+    chart: {{ template "faktory.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+    {{- range $key, $value := .Values.metrics.serviceMonitor.selector }}
+    {{ $key }}: {{ $value | quote }}
+    {{- end }}
+spec:
+  endpoints:
+    - port: metrics
+      {{- if .Values.metrics.serviceMonitor.interval }}
+      interval: {{ .Values.metrics.serviceMonitor.interval }}
+      {{- end }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ include "faktory.name" . }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
+  namespaceSelector:
+    matchNames:
+      - {{ .Release.Namespace }}
+{{- end -}}

--- a/faktory/templates/statefulset.yaml
+++ b/faktory/templates/statefulset.yaml
@@ -127,6 +127,27 @@ spec:
               mountPath: /etc/faktory/conf.d
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
+{{- if .Values.metrics.enabled }}
+        - name: metrics-exporter
+          image: "{{ .Values.metrics.image.repository }}:{{ .Values.metrics.image.tag }}"
+          imagePullPolicy: {{ .Values.metrics.image.pullPolicy }}
+          ports:
+            - containerPort: 9386
+              name: metrics
+          env:
+            - name: FAKTORY_PASSWORD
+              valueFrom:
+                secretKeyRef:
+{{- if .Values.passwordExistingSecret }}
+                  name: {{ .Values.passwordExistingSecret.name }}
+                  key: {{ .Values.passwordExistingSecret.key }}
+{{- else }}
+                  name: {{ include "faktory.fullname" . }}
+                  key: password
+{{- end }}
+            - name: FAKTORY_URL
+              value: tcp://:$(FAKTORY_PASSWORD)@localhost:7419
+{{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/faktory/values.yaml
+++ b/faktory/values.yaml
@@ -203,3 +203,16 @@ metrics:
     repository: envek/faktory_exporter
     tag: 0.4.1
     pullPolicy: IfNotPresent
+  serviceMonitor:
+    enabled: false
+    ## Specify a namespace if needed
+    # namespace: monitoring
+    # fallback to the prometheus default unless specified
+    # interval: 10s
+    ## Set of labels that need to be present in ServiceMonitor to be discovered by Prometheus:
+    ## [Prometheus Selector Label](https://github.com/bitnami/charts/tree/master/bitnami/prometheus-operator#prometheus-operator-1)
+    ## [Kube Prometheus Selector Label](https://github.com/bitnami/charts/tree/master/bitnami/prometheus-operator#exporters)
+    ## E.g. if you use prometheus-operator:
+    # selector:
+    #   release: prometheus-operator
+    selector: {}

--- a/faktory/values.yaml
+++ b/faktory/values.yaml
@@ -213,6 +213,6 @@ metrics:
     ## [Prometheus Selector Label](https://github.com/bitnami/charts/tree/master/bitnami/prometheus-operator#prometheus-operator-1)
     ## [Kube Prometheus Selector Label](https://github.com/bitnami/charts/tree/master/bitnami/prometheus-operator#exporters)
     ## E.g. if you use prometheus-operator:
-    # selector:
+    # labels:
     #   release: prometheus-operator
-    selector: {}
+    labels: {}

--- a/faktory/values.yaml
+++ b/faktory/values.yaml
@@ -196,3 +196,10 @@ securityContext:
   capabilities:
     add:
       - SYS_PTRACE
+
+metrics:
+  enabled: false
+  image:
+    repository: envek/faktory_exporter
+    tag: 0.4.1
+    pullPolicy: IfNotPresent


### PR DESCRIPTION
### What this PR does / why we need it:

In Faktory only server itself holds crucial information for application monitoring such as queues size and number of retries. We need to get it to our application monitoring.

### What's inside

 1. Ability to expose Faktory metrics to Prometheus via special exporter sidecar (disabled by default)
 2. ServiceMonitor custom resource that allows [Prometheus Operator](https://github.com/coreos/prometheus-operator) to automatically discover this Faktory instance and start scraping it (disabled by default, enabled with separate flag)

### Special notes for your reviewer:

Prometheus exporter image is from my fork with support for `FAKTORY_URL` environment variable added (see https://github.com/praekeltfoundation/faktory_exporter/pull/3) and some bug fixes and infrastructure changes. Also I have set up automatic builds in Docker Hub for my fork.

I created issue https://github.com/lukasmalkmus/faktory_exporter/issues/2 in upstream with question about project status.

But for now my fork is the only usable exporter.

### Checklist

- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/chart]`)