### PR TITLE
[faktory] Change kubeVersion to allow hosted kubernetes: GKE, EKS, microk8s, …

### DIFF
--- a/faktory/Chart.yaml
+++ b/faktory/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 name: faktory
 version: "0.11.0"
 appVersion: "1.4.0"
-kubeVersion: ">= 1.9.0"
+kubeVersion: ">= 1.9.0-0"
 description: A Helm chart for deploying Faktory
 home: https://github.com/contribsys/faktory
 icon: https://contribsys.com/images/faktory-logo.svg

--- a/faktory/Chart.yaml
+++ b/faktory/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: faktory
-version: "0.11.0"
+version: "0.11.1"
 appVersion: "1.4.0"
 kubeVersion: ">= 1.9.0-0"
 description: A Helm chart for deploying Faktory


### PR DESCRIPTION
#### What this PR does / why we need it:

Fixes error like this on `helm install faktory adwerx/faktory`:

```
Error: chart requires kubeVersion: >= 1.9.0 which is incompatible with Kubernetes v1.18.2-41+b5cdb79a4060a3
```

Sometimes SemVer is really confusing…

See https://github.com/helm/helm/issues/3810 for reference

#### Which issue this PR fixes

#### Checklist

- [x] [Developer Certificate of Origin](./CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped ([SEMVER 2](https://semver.org/))
- [x] Title of the PR starts with chart name (e.g. `[example]: Add service for feature xyz`)
