### PR TITLE
[awx]: Fix separator key values for database host in environment.sh

### DIFF
--- a/awx/Chart.yaml
+++ b/awx/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: AWX provides a web-based user interface, REST API, and task engine built on top of Ansible. It is the upstream project for Tower, a commercial derivative of AWX.
 name: awx
-version: "2.2.2"
+version: "2.2.3"
 keywords:
   - ansible
   - awx

--- a/awx/files/conf.d/environment.sh
+++ b/awx/files/conf.d/environment.sh
@@ -1,9 +1,9 @@
 DATABASE_USER={{ .Values.postgresql.postgresqlUsername }}
 DATABASE_NAME={{ .Values.postgresql.postgresqlDatabase }}
 {{- if .Values.postgresql.postgresqlHost }}
-DATABASE_HOST: {{ .Values.postgresql.postgresqlHost }}
+DATABASE_HOST={{ .Values.postgresql.postgresqlHost }}
 {{ else }}
-DATABASE_HOST: {{ .Release.Name }}-postgresql
+DATABASE_HOST={{ .Release.Name }}-postgresql
 {{ end -}}
 DATABASE_PORT={{ .Values.postgresql.service.port }}
 DATABASE_PASSWORD={{ .Values.postgresql.postgresqlPassword }}


### PR DESCRIPTION
#### What this PR does / why we need it:
This PR fix the separator in the file `environment.sh` for key `DATABASE_HOST`.

When you deploy the helm you have an error during startup due to the wrong separator : 
`awx /etc/tower/conf.d/environment.sh: line 3: DATABASE_HOST:: command not found`

We use `=` instead of `:` which I think is a wrong copy/paste from credentials.py


#### Which issue this PR fixes
No issue created for this PR

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [Developer Certificate of Origin](./CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped ([SEMVER 2](https://semver.org/))
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[example]: Add service for feature xyz`)
