### PR TITLE
[github-actions-runner]: Refactor ordering of StatefulSet blocks

### DIFF
--- a/github-actions-runner/Chart.yaml
+++ b/github-actions-runner/Chart.yaml
@@ -5,5 +5,5 @@ description: |
   allowing you to run your [GitHub Actions](https://github.com/features/actions) workflows on your
   own infrastructure.
 type: application
-version: "0.10.2"
+version: "0.10.3"
 appVersion: "2.276.1-20.04-1"

--- a/github-actions-runner/templates/statefulset.yaml
+++ b/github-actions-runner/templates/statefulset.yaml
@@ -76,6 +76,18 @@ spec:
       {{- if .Values.hostNetwork.enabled }}
       hostNetwork: true
       {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
         - name: runner
           securityContext:
@@ -163,15 +175,3 @@ spec:
             {{- end }}
   {{- end }}
 {{- end }}
-      {{- with .Values.nodeSelector }}
-      nodeSelector:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
-      {{- with .Values.affinity }}
-      affinity:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
-      {{- with .Values.tolerations }}
-      tolerations:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}


### PR DESCRIPTION
#### What this PR does / why we need it:

Currently, if `persistence.enabled` is `true` and `persistence.existingClaim` is not set then Helm will throw the following error `error validating data: ValidationError(StatefulSet.spec.volumeClaimTemplates[0]): unknown field "nodeSelector" in io.k8s.api.core.v1.PersistentVolumeClaim`. This is because this combination of values causes a `volumeClaimTemplates` block to be generated before the `nodeSelector`, `affinity` and `tolerations` blocks and so these blocks are treated as attributes of the `PersistentVolumeClaim` instead of the `Pod`.

#### Checklist
- [ ] [Developer Certificate of Origin](./CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped ([SEMVER 2](https://semver.org/))
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[example]: Add service for feature xyz`)
