### PR TITLE
Make the port names compatible with Istio

### DIFF
--- a/faktory/templates/server-service.yaml
+++ b/faktory/templates/server-service.yaml
@@ -17,7 +17,7 @@ spec:
       protocol: TCP
 {{- if .Values.metrics.enabled }}
     - port: 9386
-      name: metrics
+      name: tcp-metrics
       targetPort: metrics
 {{- end }}
   selector:

--- a/faktory/templates/server-service.yaml
+++ b/faktory/templates/server-service.yaml
@@ -12,7 +12,7 @@ spec:
   clusterIP: None
   ports:
     - port: 7419
-      name: server
+      name: tcp-server
       targetPort: server
       protocol: TCP
 {{- if .Values.metrics.enabled }}

--- a/faktory/templates/server-service.yaml
+++ b/faktory/templates/server-service.yaml
@@ -17,7 +17,7 @@ spec:
       protocol: TCP
 {{- if .Values.metrics.enabled }}
     - port: 9386
-      name: tcp-metrics
+      name: http-metrics
       targetPort: metrics
 {{- end }}
   selector:

--- a/faktory/templates/ui-ingress.yaml
+++ b/faktory/templates/ui-ingress.yaml
@@ -35,7 +35,7 @@ spec:
           - path: {{ . }}
             backend:
               serviceName: {{ $fullName }}-ui
-              servicePort: ui
+              servicePort: http-ui
         {{- end }}
   {{- end }}
 {{- end }}

--- a/faktory/templates/ui-service.yaml
+++ b/faktory/templates/ui-service.yaml
@@ -12,7 +12,7 @@ spec:
   type: {{ .Values.ui.service.type }}
   ports:
     - port: {{ .Values.ui.service.port }}
-      name: ui
+      name: http-ui
       targetPort: ui
   selector:
     app.kubernetes.io/name: {{ include "faktory.name" . }}


### PR DESCRIPTION
#### What this PR does / why we need it: 
Makes the port names compatible with Istio.

Right now the if the helm chart is deployed in an istio enabled cluster, it fails to register the service as a part of the mesh because of https://istio.io/latest/docs/reference/config/analysis/ist0118/.

Reference - https://istio.io/latest/docs/ops/configuration/traffic-management/protocol-selection/

PS: Thanks for your work on the helm chart. Really appreciate it 😃 