### PR TITLE
add serviceAnnotation parameter

### DIFF
--- a/awx/templates/web-service.yaml
+++ b/awx/templates/web-service.yaml
@@ -7,6 +7,10 @@ metadata:
     helm.sh/chart: {{ include "awx.chart" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- if .Values.service.serviceAnnotations }}
+  annotations:
+{{ toYaml .Values.service.serviceAnnotations | indent 4 }}
+{{- end }}
 spec:
   type: {{ .Values.service.type }}
   ports:


### PR DESCRIPTION
add serviceAnnotation parameter so that we can add cloud specific annotations to aws service endpoint

<!--
Thank you for contributing to our charts repo. Before you submit this PR we'd like to
make sure you are aware of our contributing guide:

* [CONTRIBUTING.md](./CONTRIBUTING.md)

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them.
-->

#### What this PR does / why we need it:
Add serviceAnnotation parameter so that we can add cloud specific annotations to awx service endpoint

#### Which issue this PR fixes
None

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] [Developer Certificate of Origin](./CONTRIBUTING.md#sign-your-work) signed
- [ ] Chart Version bumped ([SEMVER 2](https://semver.org/))
- [ ] Variables are documented in the README.md
- [ ] Title of the PR starts with chart name (e.g. `[example]: Add service for feature xyz`)
