### PR TITLE
[faktory]: Update chart ingress API for use in Kubernetes v1.22

### DIFF
--- a/faktory/Chart.yaml
+++ b/faktory/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: faktory
-version: "0.12.1"
+version: "0.12.2"
 appVersion: "1.6.0"
 kubeVersion: ">= 1.9.0-0"
 description: A Helm chart for deploying Faktory

--- a/faktory/README.md
+++ b/faktory/README.md
@@ -126,7 +126,8 @@ ui:
     hosts:
       - host: example.com
         paths:
-          - /faktory
+          - path: /faktory
+            pathType: ImplementationSpecific
     annotations:
       nginx.ingress.kubernetes.io/configuration-snippet: |
         proxy_set_header X-Script-Name /faktory;

--- a/faktory/templates/ui-ingress.yaml
+++ b/faktory/templates/ui-ingress.yaml
@@ -1,8 +1,18 @@
-# remove this
-# use port-forward or create own ingress
 {{- if .Values.ui.ingress.enabled -}}
 {{- $fullName := include "faktory.fullname" . }}
+{{- $svcPort := .Values.ui.service.port -}}
+{{- if and .Values.ui.ingress.className (not (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion)) }}
+  {{- if not (hasKey .Values.ui.ingress.annotations "kubernetes.io/ingress.class") }}
+  {{- $_ := set .Values.ui.ingress.annotations "kubernetes.io/ingress.class" .Values.ui.ingress.className}}
+  {{- end }}
+{{- end }}
+{{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1
+{{- else if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1beta1
+{{- else -}}
 apiVersion: extensions/v1beta1
+{{- end }}
 kind: Ingress
 metadata:
   name: {{ $fullName }}
@@ -16,7 +26,10 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
-{{- if .Values.ui.ingress.tls }}
+  {{- if and .Values.ui.ingress.className (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion) }}
+  ingressClassName: {{ .Values.ui.ingress.className }}
+  {{- end }}
+  {{- if .Values.ui.ingress.tls }}
   tls:
   {{- range .Values.ui.ingress.tls }}
     - hosts:
@@ -32,10 +45,20 @@ spec:
       http:
         paths:
         {{- range .paths }}
-          - path: {{ . }}
+          - path: {{ .path }}
+            {{- if and .pathType (semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion) }}
+            pathType: {{ .pathType }}
+            {{- end }}
             backend:
+              {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
+              service:
+                name: {{ $fullName }}-ui
+                port:
+                  number: {{ $svcPort }}
+              {{- else }}
               serviceName: {{ $fullName }}-ui
-              servicePort: http-ui
+              servicePort: {{ $svcPort }}
+              {{- end }}
         {{- end }}
   {{- end }}
 {{- end }}

--- a/faktory/values.yaml
+++ b/faktory/values.yaml
@@ -55,7 +55,10 @@ ui:
       # cert-manager.io/cluster-issuer: letsencrypt
     hosts: []
       # - host: chart-example.local
-      #   paths: []
+      #   paths:
+      #     - path: /
+      #       pathType: ImplementationSpecific
+
     tls: []
     #  - secretName: chart-example-tls
     #    hosts:


### PR DESCRIPTION
@jbielick

#### What this PR does / why we need it:

This PR updates the chart ingress.yaml template to use the `networking.k8s.io/v1` API so that it works with Kubernetes v1.22 and beyond because `networking.k8s.io/v1beta1` will be removed in Kubernetes v1.22.

The changes are based on the ingress template generated via `helm create` from helm v3.8.2.

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #42

#### Special notes for your reviewer:
None

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [Developer Certificate of Origin](./CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped ([SEMVER 2](https://semver.org/))
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[example]: Add service for feature xyz`)
