### PR TITLE
[faktory] fix character preventing from using any extraEnv

### DIFF
--- a/faktory/templates/statefulset.yaml
+++ b/faktory/templates/statefulset.yaml
@@ -89,7 +89,7 @@ spec:
 {{- end }}
 {{- end }}
 {{- range $key, $value := .Values.extraEnv }}
-            — name: {{ $key }}
+            - name: {{ $key }}
               value: {{ $value }}
 {{- end }}
           ports:


### PR DESCRIPTION
avoid Error: YAML parse error on faktory/templates/statefulset.yaml when values.yaml contains extraEnv

<!--
Thank you for contributing to our charts repo. Before you submit this PR we'd like to
make sure you are aware of our contributing guide:

* [CONTRIBUTING.md](./CONTRIBUTING.md)

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them.
-->

#### What this PR does / why we need it:

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] [Developer Certificate of Origin](./CONTRIBUTING.md#sign-your-work) signed
- [ ] Chart Version bumped ([SEMVER 2](https://semver.org/))
- [ ] Variables are documented in the README.md
- [ ] Title of the PR starts with chart name (e.g. `[example]: Add service for feature xyz`)
