### PR TITLE
[faktory] Refactor image helper function

### DIFF
--- a/faktory/README.md
+++ b/faktory/README.md
@@ -72,6 +72,10 @@ https://github.com/kubernetes/kubernetes/issues/24215
 |-----|------|---------|-------------|
 | affinity | object | `{}` |  |
 | config | string | `nil` | A ConfigMap structure of config file names (keys) and config file contents (values). |
+| configWatcher.image.registry | string | `"docker.io"` |  |
+| configWatcher.image.pullPolicy | string | `"IfNotPresent"` |  |
+| configWatcher.image.repository | string | `"library/busybox"` |  |
+| configWatcher.image.tag | string | `"latest"` |  |
 | environment | string | `"production"` | The Faktory server environment |
 | extraEnv | object | `{}` | key-value map of variables to define |
 | global.faktory | object | `{}` |  |
@@ -87,6 +91,7 @@ https://github.com/kubernetes/kubernetes/issues/24215
 | livenessProbe.successThreshold | int | `1` |  |
 | livenessProbe.timeoutSeconds | int | `5` |  |
 | metrics.enabled | bool | `false` | Whether to enable third-party prometheus exporter for faktory metrics |
+| metrics.image.registry | string | `"docker.io"` |  |
 | metrics.image.pullPolicy | string | `"IfNotPresent"` |  |
 | metrics.image.repository | string | `"envek/faktory_exporter"` |  |
 | metrics.image.tag | string | `"0.4.1"` |  |

--- a/faktory/templates/_helpers.tpl
+++ b/faktory/templates/_helpers.tpl
@@ -35,15 +35,8 @@ Create chart name and version as used by the chart label.
 Returns Faktory image name
 */}}
 {{- define "faktory.image" -}}
-{{- if .Values.global }}
-    {{- if .Values.global.imageRegistry }}
-        {{- printf "%s/%s:%s" .Values.global.imageRegistry .Values.image.repository .Values.image.tag -}}
-    {{- else -}}
-        {{- printf "%s/%s:%s" .Values.image.registry .Values.image.repository .Values.image.tag -}}
-    {{- end -}}
-{{- else -}}
-    {{- printf "%s/%s:%s" .Values.image.registry .Values.image.repository .Values.image.tag -}}
-{{- end -}}
+{{ $imageRegistry := coalesce .global.imageRegistry .image.registry }}
+{{- printf "%s/%s:%s" $imageRegistry .image.repository .image.tag -}}
 {{- end -}}
 
 {{/*

--- a/faktory/templates/statefulset.yaml
+++ b/faktory/templates/statefulset.yaml
@@ -27,7 +27,8 @@ spec:
       {{- include "faktory.imagePullSecrets" . | indent 6 }}
       containers:
         - name: config-watcher
-          image: busybox
+          image: "{{ template "faktory.image" dict "image" .Values.configWatcher.image "global" .Values.global }}"
+          imagePullPolicy: {{ .Values.configWatcher.image.pullPolicy }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
           command:
@@ -53,7 +54,7 @@ spec:
             - name: configs
               mountPath: /conf
         - name: server
-          image: "{{ include "faktory.image" . }}"
+          image: "{{ template "faktory.image" dict "image" .Values.image "global" .Values.global }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           command:
             - /faktory
@@ -129,7 +130,7 @@ spec:
             {{- toYaml .Values.resources | nindent 12 }}
 {{- if .Values.metrics.enabled }}
         - name: metrics-exporter
-          image: "{{ .Values.metrics.image.repository }}:{{ .Values.metrics.image.tag }}"
+          image: "{{ template "faktory.image" dict "image" .Values.metrics.image "global" .Values.global }}"
           imagePullPolicy: {{ .Values.metrics.image.pullPolicy }}
           ports:
             - containerPort: 9386

--- a/faktory/values.yaml
+++ b/faktory/values.yaml
@@ -188,10 +188,18 @@ securityContext:
     add:
       - SYS_PTRACE
 
+configWatcher:
+  image:
+    registry: docker.io
+    repository: library/busybox
+    tag: "latest"
+    pullPolicy: IfNotPresent
+
 metrics:
   # -- Whether to enable third-party prometheus exporter for faktory metrics
   enabled: false
   image:
+    registry: docker.io
     repository: envek/faktory_exporter
     tag: 0.4.1
     pullPolicy: IfNotPresent


### PR DESCRIPTION
#### What this PR does / why we need it:

This is a refactor of the image helper function so it can be re-used for all containers for consistent behaviour:
- Now the image configuration for the config watcher container can be changed
- Support the `global.imageRegistry` for all all containers.

Our usecase is a kubernetes cluster configured without access to the public Docker registry, as a security measure. Instead, we rely exclusively on an internal mirror for pulling all images. We were unable to deploy the chart on this cluster as it was hardcoded to pull the busybox image from DockerHub.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [Developer Certificate of Origin](./CONTRIBUTING.md#sign-your-work) signed
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[example]: Add service for feature xyz`)
